### PR TITLE
Supplying Bower support

### DIFF
--- a/aero/adapters/__init__.py
+++ b/aero/adapters/__init__.py
@@ -27,6 +27,7 @@ from .brew import Brew
 from .port import Port
 from .pip import Pip
 from .npm import Npm
+from .bower import Bower
 from .gem import Gem
 from .pear import Pear
 from .pecl import Pecl

--- a/aero/adapters/bower.py
+++ b/aero/adapters/bower.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+__author__ = 'oliveiraev'
+__all__ = ['Bower']
+
+from re import sub
+from re import split
+from aero.__version__ import enc
+from .base import BaseAdapter
+
+
+class Bower(BaseAdapter):
+    """
+    Twitter Bower - Browser package manager - Adapter
+    """
+    def search(self, query):
+        response = self.command('search', query)[0].decode(*enc)
+        lst = list(
+            self.__parse_search(line) for line in response.splitlines()
+            if line.startswith('  - ')
+        )
+        if lst:
+            return dict([(k, v) for k, v in lst if k != 0])
+        return {}
+
+    def __parse_search(self, result):
+        result = split('\[\d\dm', result, 2)
+        if isinstance(result, (list, tuple)) and len(result) > 1:
+            return self.package_name(result[1][:-1]), '\n'
+        return 0, 0
+
+    def install(self, query):
+        return self.shell('install', query)
+
+    def info(self, query):
+        response = self.command('view', query)[0].decode(*enc)
+        return response or ['Aborted: No info available']


### PR DESCRIPTION
Info, search and install commands available.

``` bash
    aero search bower:jquery
    aero install bower:html5-boilerplate
```

Info command currently does not return any information.

Didn't found any test. They exists?

While it's my first and humble contribution, I'm not comfortable with increasing dependency list. But we can grab Bower packages information with curl, looking for the readme's inside repository addresses provided by the search.

At my tests, I could perform search only after disabling pip `aero search -d pip jquery`

I'm testing with the following workflow
1. Mod's and save
2. `python setup.py install --force`
3. `aero some command`

There is any smarter way?
