### PR TITLE
Update apt.py: Python golf!

### DIFF
--- a/aero/adapters/apt.py
+++ b/aero/adapters/apt.py
@@ -14,22 +14,13 @@ class Apt(BaseAdapter):
 
     def search(self, query):
         response = self._execute_command(self.search_command, ['search', query])[0].decode(*enc)
-        lst = {}
-        from re import match
-        lst.update([
-            match('^([^ ]*) - (.*)', 'apt:'+line).groups()
-            for line in response.splitlines()
-            if match('^([^ ]*) - (.*)', line)
-        ])
-        return lst
+        import re
+        regex = re.compile('^([^ ]*) - (.*)')
+        return { 'apt:'+m.group(1): m.group(2) for m in map(regex.match, response.splitlines()) if m }
 
     def info(self, query):
         response = self._execute_command(self.search_command, ['show', query])[0].decode(*enc)
-        lst = [
-            line.split(': ') if line.find(': ') > 0 else ('',line)
-            for line in response.splitlines()
-        ]
-        return self.munge_lines(lst)
+        return self.munge_lines([(a, b) for a, _, b in map(lambda s: s.rpartition(': '), response.splitlines)])
 
     def install(self, query):
         return self.shell('install', query)


### PR DESCRIPTION
Untested, should work down to python 2.7 though. Python versions prior to 2.7 do not have dict comprehension.

These changes should reduce overhead by only doing re.match/str.find once instead of twice.

Depending on the amount of matching this needs to do, it might be worth considering [re2](https://code.google.com/p/re2/) instead of python's default re.
